### PR TITLE
fix base url for api section

### DIFF
--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -19,7 +19,7 @@
             {{ if not .Site.Params.ui.breadcrumb_disable }}{{ partial "breadcrumb.html" . }}{{ end }}
             {{ block "main" . }}{{ end }}
             <div class="iframe-container">
-              <iframe src="https://sogno-platform.github.io/{{ .Params.apiurl }}" width="100%" height="768" frameborder="0" allowfullscreen="allowfullscreen" ></iframe>
+              <iframe src="https://sogno.energy/{{ .Params.apiurl }}" width="100%" height="768" frameborder="0" allowfullscreen="allowfullscreen" ></iframe>
             </div>
           </main>
         </div>


### PR DESCRIPTION
This PR should fix the API specification iframes in the API section of the docs. 
Issue: it was still pointing to the old github.io base url

Signed-off-by: Jonas Baude <jonas.baude@eonerc.rwth-aachen.de>